### PR TITLE
Fix PHP Notices

### DIFF
--- a/config/localConfig.template.php
+++ b/config/localConfig.template.php
@@ -29,4 +29,6 @@ $db_user_table    = 'users';
 $db_reports_table = 'reports';
 $dsn              = "{$db_type}:host={$db_host};port={$db_port};dbname={$db_name}";
 
+date_default_timezone_set("");
+
 $debug = false;

--- a/lib/quail/quail/common/accessibility_tests.php
+++ b/lib/quail/quail/common/accessibility_tests.php
@@ -1190,8 +1190,8 @@ class cssTextHasContrast extends quailColorTest
 				$bold = false;
 
 				if (isset($style['font-size'])) {
-					preg_match_all('!\d+!', $style['font-size'], $matches);
-					$font_size = $matches[0][0];
+					$matchCount = preg_match_all('!\d+!', $style['font-size'], $matches);
+					if($matchCount){$font_size = $matches[0][0];}
 				}
 
 				if (isset($style['font-weight'])) {
@@ -1279,8 +1279,8 @@ class cssTextStyleEmphasize extends quailColorTest
 				$bold = false;
 
 				if (isset($style['font-size'])) {
-					preg_match_all('!\d+!', $style['font-size'], $matches);
-					$font_size = $matches[0][0];
+					$matchCount = preg_match_all('!\d+!', $style['font-size'], $matches);
+					if($matchCount){$font_size = $matches[0][0];}
 				}
 
 				if (isset($style['font-weight'])) {

--- a/lib/quail/quail/reporters/reporter.static.php
+++ b/lib/quail/quail/reporters/reporter.static.php
@@ -76,7 +76,7 @@ class reportStatic extends quailReporter
 									$styleValue = $name->value;
 									$hexColors  = [];
 
-									preg_match_all("/(#[0-9a-f]{6}|#[0-9a-f]{3})/", $styleValue, $hexColors);
+									$matchCount = preg_match_all("/(#[0-9a-f]{6}|#[0-9a-f]{3})/", $styleValue, $hexColors);
 
 									$hexColors = array_unique($hexColors[0]);
 								}
@@ -87,8 +87,10 @@ class reportStatic extends quailReporter
 							if ( sizeof($hexColors) === 1 ) {
 								$testResult['fore_color'] = $hexColors[0];
 							} else {
-								$testResult['back_color'] = $hexColors[0];
-								$testResult['fore_color'] = $hexColors[1];
+								if($matchCount){
+									$testResult['back_color'] = $hexColors[0];
+									$testResult['fore_color'] = $hexColors[1];
+								}
 							}
 						}
 


### PR DESCRIPTION
Add ability to set timezone to avoid PHP Notice. Count the number of
matches from preg_matches to avoid undefined offset PHP notice.
